### PR TITLE
3DVIEWの分割画面だと、主エリア以外の法線判定処理が主エリアの内容になっていただめ表示が微妙に違った。

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -124,7 +124,10 @@ class ConfirmWireOperator(bpy.types.Operator):
 
             indices.append((e.verts[0].index, e.verts[1].index))
 
-        coords = [v.co + obj.location for v in bm.verts]
+        coords = []
+        for v in bm.verts:
+            coords.append(v.co + obj.location)
+
         if prop.cw_is_flip_horizontal:
             coords = [(v[0]*-1, v[1], v[2]) for v in coords]
 

--- a/helper.py
+++ b/helper.py
@@ -14,13 +14,6 @@
 import bpy
 import math
 
-def get_area_view_3d(context):
-    for area in context.screen.areas:
-        if area.type == 'VIEW_3D':
-            return area
-    else:
-        return None
-
 # def get_region_view_3d(context):
 #     area = get_area_view_3d(context)
 #     if area is None:
@@ -32,9 +25,9 @@ def get_area_view_3d(context):
 #     else:
 #         return None
 
-# SpaceView3Dを取得する
+# アクティブなエリアのSpaceView3Dを取得する
 def get_space_view_3d(context):
-    aria = get_area_view_3d(context)
+    aria = bpy.context.area
     if aria is None:
         return None
 


### PR DESCRIPTION
エリアごとの法線判定になるように共通処理を修正した